### PR TITLE
Test for multiple splices before encoding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@colyseus/schema",
-  "version": "0.5.2",
+  "version": "0.5.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
I'm leaving it as a note for future.
https://discordapp.com/channels/525739117951320081/526083213383434252/653304884409532417

---

Ok, I see two things. In my case:
```
// [ A, B, C ]
items.splice(0,1) // Remove first item, A
items.splice(0,1) // now the first item is B, so remove that
```
1) The `items.$changes.deletedKeys` has only one entry, which is `{ 0: true }`. Thats because, for each `splice` I was removing the first item. But it couldn't remember that I removed two items, which were at index 0 on each `splice`.
2) `items.$changes.indexChange` at that point would have both remaining items (B and C), but with incorrect values (B->1, C->2). If of cource I understand it correctly, as *"Item B changed its index to 1"*, but in reality it got moved to index 0.

I don't understand Schema enough to dig deeper, so I'll just try to avoid this issue by grouping my splices and/or waiting for next encoding/patch cycle.